### PR TITLE
Use double braces for expressions

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -10,7 +10,7 @@
 
 - name: Create additional plugins config
   template: dest="{{monasca_conf_dir}}/agent/conf.d/{{item.key}}.yaml" src=plugin.yaml.j2 owner=root group=root mode=644
-  with_dict: monasca_checks
+  with_dict: "{{ monasca_checks }}"
   notify: run monasca-setup
 
 # Instead of running this directly by creating a file to run it changes such as user/pass will trigger a rerun. Also a user can run it manually

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -5,12 +5,12 @@
 
 - name: Install deps to avoid pip doing compilation or enable it
   apt: name={{item}} state=present
-  with_items: dependencies_deb
+  with_items: "{{ dependencies_deb }}"
   when: ansible_os_family == 'Debian'
-  
+
 - name: Install rpms to avoid pip doing compilation or enable it
   yum: name={{item}} state=present
-  with_items: dependencies_rpm
+  with_items: "{{ dependencies_rpm }}"
   when: ansible_os_family == 'RedHat'
 
 - name: Upgrade pip in virtualenv


### PR DESCRIPTION
To prevent these variables being interpreted as strings wrap them
in double braces.