### PR TITLE
Extend arguments passed to Monasca setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,14 @@ virtualenv must be installed on the system.
 - monasca_api_url: if undefined it will be pulled from the keystone service catalog.
 - monasca_agent_version: Defines a specific version to install, defaults to latest
 - monasca_log_level: Log level of the agent logs, default is WARN
+- monasca_endpoint_type: Keystone endpoint type for monitoring service, eg: public, internal etc.
+- monasca_project_domain_name: Keystone project domain name for Monasca
+- monasca_project_domain_id: Keystone project domain ID for Monasca
+- monasca_region_name: Keystone API URL region name for Monasca
+- monasca_service_type: Keystone API URL service type for Monasca
+- monasca_user_domain_name: Keystone project domain name for Monasca
+- monasca_user_domain_id: Keystone project domain ID for Monasca
+
 - pip_index_url: Index URL to use instead of the default for installing pip packages
 - run_mode: One of Deploy, Stop, Install, Start, or Use. The default is Deploy which will do Install, Configure, then Start. 'Use' can be set if the only desire is to use the monasca_agent_plugin module
 

--- a/templates/monasca-reconfigure.j2
+++ b/templates/monasca-reconfigure.j2
@@ -10,4 +10,11 @@
     {% if monasca_agent_check_frequency is defined %} --check_frequency '{{monasca_agent_check_frequency}}' {% endif %} \
     {% if monasca_agent_system_only %} --system_only {% endif %} \
     {% if monasca_log_level is defined %} --log_level '{{monasca_log_level}}' {% endif %} \
+    {% if monasca_endpoint_type is defined %} --endpoint_type '{{monasca_endpoint_type}}' {% endif %} \
+    {% if monasca_project_domain_name is defined %} --project_domain_name '{{monasca_project_domain_name}}' {% endif %} \
+    {% if monasca_project_domain_id is defined %} --project_domain_id '{{monasca_project_domain_id}}' {% endif %} \
+    {% if monasca_region_name is defined %} --region_name '{{monasca_region_name}}' {% endif %} \
+    {% if monasca_service_type is defined %} --service_type '{{monasca_service_type}}' {% endif %} \
+    {% if monasca_user_domain_name is defined %} --user_domain_name '{{monasca_user_domain_name}}' {% endif %} \
+    {% if monasca_user_domain_id is defined %} --user_domain_id '{{monasca_user_domain_id}}' {% endif %} \
     --overwrite


### PR DESCRIPTION
This patch extends the number of arguments which can be passed
to Monasca setup. The additional arguments may be required by
some operators to correctly configure the Monasca agent for their
environment.