### PR TITLE
Support installing from git repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ virtualenv must be installed on the system.
 - monasca_agent_dimensions: 'role:monitoring,region:a'
 - monasca_api_url: if undefined it will be pulled from the keystone service catalog.
 - monasca_agent_version: Defines a specific version to install, defaults to latest
+- monasca_agent_branch: Defines a specific branch to install. Ignored if monasca_agent_version is set.
 - monasca_log_level: Log level of the agent logs, default is WARN
 - monasca_endpoint_type: Keystone endpoint type for monitoring service, eg: public, internal etc.
 - monasca_project_domain_name: Keystone project domain name for Monasca

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -27,12 +27,19 @@
 - name: pip install latest monasca-agent in a virtualenv
   pip: name=monasca-agent state=latest virtualenv="{{monasca_virtualenv_dir}}"
   notify: run monasca-setup
-  when: monasca_agent_version is not defined
+  when: monasca_agent_version is not defined and monasca_agent_branch is not defined
 
 - name: pip install a specific version of monasca-agent in a virtualenv
   pip: name=monasca-agent state=present version="{{monasca_agent_version}}" virtualenv="{{monasca_virtualenv_dir}}"
   notify: run monasca-setup
   when: monasca_agent_version is defined
+
+- name: pip install a specific branch of monasca-agent in a virtualenv
+  pip:
+    name: "git+https://git.openstack.org/openstack/monasca-agent@{{ monasca_agent_branch }}"
+    virtualenv: "{{ monasca_virtualenv_dir }}"
+    editable: False
+  when: monasca_agent_branch is defined and monasca_agent_version is not defined
 
 - name: pip install psutil==3.0.1
   pip: name=psutil version=3.0.1 virtualenv="{{monasca_virtualenv_dir}}"


### PR DESCRIPTION
Monasca-agent versions are not tied to specific git branches. This
change supports installing from specific git branches.

This change was motivated by the tornado library deprecating a parameter which broke the monaca-agent. The fix is available on master and stable branches, and also in the latest tagged version, but the latest tagged version is broken by this bug:

https://review.openstack.org/#/c/550466/