### PR TITLE
install lshw as dependency

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -11,6 +11,7 @@ dependencies_deb:
   - libxslt1-dev
   - libffi-dev
   - libssl-dev
+  - lshw
 dependencies_redhat:
   - python-devel
   - python-pip
@@ -21,6 +22,7 @@ dependencies_redhat:
   - libffi-devel
   - openssl-devel
   - gcc
+  - lshw
 dependencies_suse:
   - python-devel
   - python-pip
@@ -31,6 +33,7 @@ dependencies_suse:
   - libffi-devel
   - openssl-devel
   - gcc
+  - lshw
 monasca_conf_dir: /etc/monasca
 monasca_agent_check_plugin_dir: /usr/lib/monasca/agent/custom_checks.d
 monasca_agent_detection_plugin_dir: /usr/lib/monasca/agent/custom_detect.d


### PR DESCRIPTION
I got this error when running task `[stackhpc.monasca-agent : run monasca-setup]` that executes script `/usr/local/bin/monasca-reconfigure` in the host. I could workaround it by installing `lshw` 

```
INFO:   Configured load
INFO:   Configured memory
INFO:   Configured cpu
INFO: Configuring System
WARNING: Nova-compute process exists but the configuration file was not detected and no arguments were given.
INFO: Zookeeper process has not been found: Plugin for Zookeeper will not be configured.
INFO: Infiniband hardware was not detected: ib_network pluginwill not be loaded.
Traceback (most recent call last):
  File "/opt/monasca/bin/monasca-setup", line 10, in <module>
    sys.exit(main())
  File "/opt/monasca/lib/python2.7/site-packages/monasca_setup/main.py", line 107, in main
    is None))
  File "/opt/monasca/lib/python2.7/site-packages/monasca_setup/main.py", line 466, in plugin_detection
    detect = detect_class(template_dir, False, detection_args)
  File "/opt/monasca/lib/python2.7/site-packages/monasca_setup/detection/plugin.py", line 45, in __init__
    self._detect()
  File "/usr/lib/monasca/agent/custom_detect.d/nvidia.py", line 30, in _detect
    ["lshw", "-C", "display"]).lower():
  File "/usr/lib64/python2.7/subprocess.py", line 568, in check_output
    process = Popen(stdout=PIPE, *popenargs, **kwargs)
  File "/usr/lib64/python2.7/subprocess.py", line 711, in __init__
    errread, errwrite)
  File "/usr/lib64/python2.7/subprocess.py", line 1327, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```