### PR TITLE
Add configuration necessary to install monasca-agent on CentOS 8

### DIFF
--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -37,9 +37,24 @@
     - not item.stat.islnk
   with_items: "{{ prev_paths.results }}"
 
+- name: Extract python interpreter version from virtualenv
+  command: "{{ monasca_virtualenv_dir }}/bin/python -c \"import sysconfig; print(sysconfig.get_config_var('py_version_short'))\""
+  register: py_version_short
+
+- set_fact:
+    venv_py_version: "{{ py_version_short.stdout_lines[0] }}"
+
+- name: Ensures Monasca Agent custom plugins directories exist
+  file:
+    path: "{{ monasca_virtualenv_dir }}/lib/python{{ venv_py_version }}/site-packages/{{ item | regex_replace('\\/$', '') }}"
+    state: directory
+  with_items:
+    - "{{ monasca_agent_check_plugin_dir }}"
+    - "{{ monasca_agent_detection_plugin_dir }}"
+
 - name: Link custom plugins from Monasca venv to hard coded folder searched by Monasca Agent
   file:
-    src: "{{ monasca_virtualenv_dir }}/lib/python2.7/site-packages/{{ item | regex_replace('\\/$', '') }}"
+    src: "{{ monasca_virtualenv_dir }}/lib/python{{ venv_py_version }}/site-packages/{{ item | regex_replace('\\/$', '') }}"
     dest: "{{ item | regex_replace('\\/$', '') }}"
     state: link
   with_items:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -3,20 +3,20 @@
 
 - include: pip_index.yml
 
+- name: Set OS distribution dependent variables
+  include_vars: "{{ lookup('first_found', params) }}"
+  vars:
+    params:
+      files:
+        - "deps_{{ ansible_os_family }}_{{ ansible_distribution_major_version }}.yml"
+        - "deps_{{ ansible_os_family }}.yml"
+        - "deps_default.yml"
+      paths:
+        - "vars"
+
 - name: Install deps to avoid pip doing compilation or enable it
-  apt: name={{ item }} state=present
-  with_items: "{{ dependencies_deb }}"
-  when: ansible_os_family == 'Debian'
-
-- name: Install rpms to avoid pip doing compilation or enable it
-  yum: name={{ item }} state=present
-  with_items: "{{ dependencies_redhat }}"
-  when: ansible_os_family == 'RedHat'
-
-- name: Install rpms to avoid pip doing compilation or enable it
-  zypper: name={{ item }} state=present
-  with_items: "{{ dependencies_suse }}"
-  when: ansible_os_family == 'Suse'
+  package:
+    name: "{{ monasca_os_dependencies }}"
 
 - name: Upgrade pip in virtualenv
   pip: name=pip state=latest virtualenv="{{ monasca_virtualenv_dir }}"

--- a/vars/deps_Debian.yml
+++ b/vars/deps_Debian.yml
@@ -1,0 +1,14 @@
+---
+# ©Copyright 2015-2016 Hewlett Packard Enterprise Development Company, LP
+
+monasca_os_dependencies:
+  - python-dev
+  - python-pip
+  - python-virtualenv
+  - python-yaml
+  - build-essential
+  - libxml2-dev
+  - libxslt1-dev
+  - libffi-dev
+  - libssl-dev
+  - lshw

--- a/vars/deps_RedHat_7.yml
+++ b/vars/deps_RedHat_7.yml
@@ -1,0 +1,14 @@
+---
+# ©Copyright 2015-2016 Hewlett Packard Enterprise Development Company, LP
+
+monasca_os_dependencies:
+  - python-devel
+  - python-pip
+  - python-virtualenv
+  - PyYAML
+  - libxml2-devel
+  - libxslt-devel
+  - libffi-devel
+  - openssl-devel
+  - gcc
+  - lshw

--- a/vars/deps_RedHat_8.yml
+++ b/vars/deps_RedHat_8.yml
@@ -1,0 +1,13 @@
+---
+# ©Copyright 2015-2016 Hewlett Packard Enterprise Development Company, LP
+
+monasca_os_dependencies:
+  - python3-virtualenv
+  - python3-pyyaml
+  - python3-libxml2
+  - libxml2-devel
+  - libxslt-devel
+  - libffi-devel
+  - openssl-devel
+  - gcc
+  - lshw

--- a/vars/deps_SUSE.yml
+++ b/vars/deps_SUSE.yml
@@ -14,4 +14,3 @@ monasca_os_dependencies:
   - gcc
   - lshw
 
-...

--- a/vars/deps_SUSE.yml
+++ b/vars/deps_SUSE.yml
@@ -1,0 +1,17 @@
+---
+# ©Copyright 2015-2016 Hewlett Packard Enterprise Development Company, LP
+
+
+monasca_os_dependencies:
+  - python-devel
+  - python-pip
+  - python-virtualenv
+  - python-PyYAML
+  - libxml2-devel
+  - libxslt-devel
+  - libffi-devel
+  - openssl-devel
+  - gcc
+  - lshw
+
+...

--- a/vars/deps_default.yml
+++ b/vars/deps_default.yml
@@ -1,0 +1,14 @@
+---
+# ©Copyright 2015-2016 Hewlett Packard Enterprise Development Company, LP
+
+monasca_os_dependencies:
+  - python-dev
+  - python-pip
+  - python-virtualenv
+  - python-yaml
+  - build-essential
+  - libxml2-dev
+  - libxslt1-dev
+  - libffi-dev
+  - libssl-dev
+  - lshw

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,39 +1,6 @@
 ---
 # ©Copyright 2015-2016 Hewlett Packard Enterprise Development Company, LP
 
-dependencies_deb:
-  - python-dev
-  - python-pip
-  - python-virtualenv
-  - python-yaml
-  - build-essential
-  - libxml2-dev
-  - libxslt1-dev
-  - libffi-dev
-  - libssl-dev
-  - lshw
-dependencies_redhat:
-  - python-devel
-  - python-pip
-  - python-virtualenv
-  - PyYAML
-  - libxml2-devel
-  - libxslt-devel
-  - libffi-devel
-  - openssl-devel
-  - gcc
-  - lshw
-dependencies_suse:
-  - python-devel
-  - python-pip
-  - python-virtualenv
-  - python-PyYAML
-  - libxml2-devel
-  - libxslt-devel
-  - libffi-devel
-  - openssl-devel
-  - gcc
-  - lshw
 monasca_conf_dir: /etc/monasca
 monasca_agent_check_plugin_dir: /usr/lib/monasca/agent/custom_checks.d
 monasca_agent_detection_plugin_dir: /usr/lib/monasca/agent/custom_detect.d


### PR DESCRIPTION
Different method for managing package name dependencies to enable
a distinction between CentOS 8 and CentOS 7 and portable deployment to either.